### PR TITLE
Add link to website from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hackney Developer Hub
 
-The source code behind [developer.api.hackney.gov.uk](developer.api.hackney.gov.uk).
+The source code behind [developer.api.hackney.gov.uk](http://developer.api.hackney.gov.uk).
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hackney Developer Hub
 
+The source code behind [developer.api.hackney.gov.uk](developer.api.hackney.gov.uk).
+
 ## Stack
 
 - Jekyll - Ruby static site generator


### PR DESCRIPTION
This change adds a link to the developer hub from the README.

We should also think about adding a link from the GitHub repository description.